### PR TITLE
script_comp: fix undesired resman container set mutations

### DIFF
--- a/nwn_script_comp.nim
+++ b/nwn_script_comp.nim
@@ -150,16 +150,14 @@ proc serviceRmDemand(rm: ResMan, resref: ResRef, searchPath: seq[RMSearchPathEnt
       of pcFile: resContainerCache[q[1]] = newResFile(q[1])
       else: continue
     containers.add resContainerCache[q[1]]
-  for c in containers:
-    rm.add(c)
-  defer:
-    for c in containers:
-      rm.del(c)
 
-  if not rm.contains(resref):
-    return ""
-  else:
-    return rm.demand(resref).readAll
+  containers &= rm.containers
+
+  for c in containers:
+    if c.contains(resref):
+      return c.demand(resref).readAll
+
+  return ""
 
 var chDemandResRef: Channel[tuple[
   resref: ResRef,


### PR DESCRIPTION
This commit modifies the method in which nwn_script_comp searches ResMan to deliver the desired ResRef.  Previous behavior allowed for the ResMan.containers set to be mutatated in
`nwn_script_comp::serviceRmDemand` when the deferred code was run as the scope expired.  This caused the containers within the containers set to reorder, seemingly at random, losing the load order as specified by the user, potentially causing script compilation issues, specifically with user-defined files that shadow bif-sourced files.

## Testing

Tested this change against the PRC repo, which contains multiple local files that override game/bif-sourced includes, such as `x2_inc_spellhook.nss`.  Previous to this change, `ResMan.containers` was mutated when the `serviceRmDemand` scope was exited, causing unexpected container order when demanding resrefs.  After this change, the container order remains unchanged.

## Changelog

### Fixed
script_comp: fixed resman container set order mutability issue which prevented locally overriden files from being properly served by resman.

## Licence
- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
