### PR TITLE
Add `-n` / `--no-entry-point` flag to `nwn_script_comp`

### DIFF
--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -218,3 +218,11 @@ proc scriptCompApiSetGenerateDebuggerOutput(instance: CScriptCompiler, state: ui
 
 proc setGenerateDebuggerOutput*(instance: ScriptCompiler, state: bool) =
   scriptCompApiSetGenerateDebuggerOutput(instance.compiler, if state: 1 else: 0)
+
+proc scriptCompApiSetRequireEntryPoint(instance: CScriptCompiler, state: uint32) {.importc.}
+
+proc setRequireEntryPoint*(instance: ScriptCompiler, required: bool) =
+  ## Set whether an entry point (void main or int StartingConditional) is required.
+  ## When set to false, scripts without entry points can be compiled for validation purposes.
+  ## This is useful for validating include files.
+  scriptCompApiSetRequireEntryPoint(instance.compiler, if required: 1 else: 0)

--- a/neverwinter/nwscript/compilerapi.cpp
+++ b/neverwinter/nwscript/compilerapi.cpp
@@ -73,6 +73,11 @@ extern "C" void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance
     instance->SetGenerateDebuggerOutput(state);
 }
 
+extern "C" void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state)
+{
+    instance->SetRequireEntryPoint(state);
+}
+
 extern "C" void scriptCompApiDestroyCompiler(CScriptCompiler* instance)
 {
     delete instance;

--- a/neverwinter/nwscript/compilerapi.h
+++ b/neverwinter/nwscript/compilerapi.h
@@ -127,6 +127,13 @@ EXPORT_SYMBOL void scriptCompApiSetOptimizationFlags(CScriptCompiler* instance, 
 EXPORT_SYMBOL void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance, bool state);
 
 //
+// Set whether an entry point (void main or int StartingConditional) is required.
+// When set to false, scripts without entry points can be compiled for validation purposes.
+// This is useful for validating include files.
+//
+EXPORT_SYMBOL void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state);
+
+//
 // Destroy the compiler instance. You should call this when you're done
 // using it to free allocated memory.
 //

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -249,6 +249,23 @@ public:
 	///////////////////////////////////////////////////////////////////////
 
 	///////////////////////////////////////////////////////////////////////
+	void SetRequireEntryPoint(BOOL bValue);
+	//---------------------------------------------------------------------
+	// Desc.: This routine will set whether an entry point (void main or
+	//        int StartingConditional) is required for compilation.
+	//
+	// bValue:  (IN) A value to determine whether an entry point is required.
+	//
+	//          TRUE (default):  An entry point is required. Compilation
+	//              will fail if neither void main() nor
+	//              int StartingConditional() is present.
+	//
+	//          FALSE:  No entry point is required. Useful for validating
+	//              include files that have no entry point.
+	//
+	///////////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////////
 	int32_t CompileFile(const CExoString &sFileName);
 	//---------------------------------------------------------------------
 	// Desc.: This routine will generate whether the code in the file
@@ -485,6 +502,7 @@ private:
 	BOOL m_bCompileConditionalFile;
 	BOOL m_bOldCompileConditionalFile;
 	BOOL m_bCompileConditionalOrMain;
+	BOOL m_bRequireEntryPoint;
 	CExoString m_sLanguageSource;
 	CExoString m_sOutputAlias;
 	CExoString m_sGraphvizPath;

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -341,6 +341,7 @@ CScriptCompiler::CScriptCompiler(RESTYPE nSource, RESTYPE nCompiled, RESTYPE nDe
 	m_bCompileConditionalFile = FALSE;
 	m_bOldCompileConditionalFile = FALSE;
 	m_bCompileConditionalOrMain = FALSE;
+	m_bRequireEntryPoint = TRUE;
 	m_bAutomaticCleanUpAfterCompiles = TRUE;
 
 	m_nNumEngineDefinedStructures = 0;
@@ -1144,6 +1145,14 @@ void CScriptCompiler::SetCompileConditionalFile(BOOL bValue)
 void CScriptCompiler::SetCompileConditionalOrMain(BOOL bValue)
 {
 	m_bCompileConditionalOrMain = bValue;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//  CScriptCompiler::SetRequireEntryPoint()
+///////////////////////////////////////////////////////////////////////////////
+void CScriptCompiler::SetRequireEntryPoint(BOOL bValue)
+{
+	m_bRequireEntryPoint = bValue;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -84,6 +84,14 @@ int32_t CScriptCompiler::GenerateFinalCodeFromParseTree(CExoString sFileName)
 
 	int32_t nReturnValue = InstallLoader();
 	pNewReturnTree = InsertGlobalVariablesInParseTree(pReturnTree);
+
+	// InstallLoader returns 1 when no entry point is required and none was found.
+	// In this case, parsing was successful but there is no code to generate.
+	if (nReturnValue == 1)
+	{
+		return CleanUpAfterCompile(0, pNewReturnTree);
+	}
+
 	if (nReturnValue >= 0)
 	{
 		nReturnValue = WalkParseTree(pNewReturnTree);
@@ -499,7 +507,13 @@ int32_t CScriptCompiler::InstallLoader()
 			}
 			else
 			{
-				// Neither are present, so we're going to error just as
+				// Neither are present.
+				if (m_bRequireEntryPoint == FALSE)
+				{
+					// No entry point required - signal caller to skip code generation.
+					return 1;
+				}
+				// Otherwise we're going to error just as
 				// if we are expecting a void main() function!
 				m_bCompileConditionalFile = FALSE;
 			}
@@ -511,6 +525,11 @@ int32_t CScriptCompiler::InstallLoader()
 		nMainIdentifier = GetIdentifierByName("main");
 		if (nMainIdentifier < 0)
 		{
+			if (m_bRequireEntryPoint == FALSE)
+			{
+				// No entry point required - signal caller to skip code generation.
+				return 1;
+			}
 			return STRREF_CSCRIPTCOMPILER_ERROR_NO_FUNCTION_MAIN_IN_SCRIPT;
 		}
 
@@ -532,6 +551,11 @@ int32_t CScriptCompiler::InstallLoader()
 		nMainIdentifier = GetIdentifierByName("StartingConditional");
 		if (nMainIdentifier < 0)
 		{
+			if (m_bRequireEntryPoint == FALSE)
+			{
+				// No entry point required - signal caller to skip code generation.
+				return 1;
+			}
 			return STRREF_CSCRIPTCOMPILER_ERROR_NO_FUNCTION_INTSC_IN_SCRIPT;
 		}
 

--- a/nwn_script_comp.nim
+++ b/nwn_script_comp.nim
@@ -49,6 +49,10 @@ Usage:
   -s                          Simulate: Compile, but write no file.
                               Use --verbose to see what would be written.
 
+  -n --no-entry-point         Do not require an entry point (void main or
+                              int StartingConditional). Useful for validating
+                              include files.
+
   --langspec NSS              Language spec to load [default: nwscript]
   --restype-src TYPE          ResType to use for source lookup [default: nss]
   --restype-bin TYPE          ResType to use for binary output [default: ncs]
@@ -71,6 +75,7 @@ type
     maxIncludeDepth: 1..200
     followSymlinks: bool
     graphvizOut: string
+    requireEntryPoint: bool
 
   GlobalState = object
     successes, errors, skips: Atomic[uint]
@@ -116,6 +121,7 @@ globalState.params = Params(
   maxIncludeDepth: parseInt($globalState.args["--max-include-depth"]),
   followSymlinks: globalState.args["--follow-symlinks"],
   graphvizOut: if globalState.args["--graphviz"]: ($globalState.args["--graphviz"]) else: "",
+  requireEntryPoint: not globalState.args["--no-entry-point"].to_bool,
 )
 
 if globalState.params.outDirectory != "" and not dirExists(globalState.params.outDirectory):
@@ -207,6 +213,7 @@ proc getThreadState(): ThreadState {.gcsafe.} =
     state.chDemandResRefResponse.open(maxItems=1)
     state.cNSS = newCompiler(params.langSpec, params.debugSymbols, resolveFile, params.maxIncludeDepth, params.graphvizOut)
     state.cNSS.setOptimizations(params.optFlags)
+    state.cNSS.setRequireEntryPoint(params.requireEntryPoint)
   state
 
 proc doCompile(num, total: Positive, p: string, overrideOutPath: string = "") {.gcsafe.} =


### PR DESCRIPTION
This flag allows the compilation of a file (or files) without requiring an entry point (`void main` or `StartingConditional`). Useful for validating files, the main purpose for its creation is compatibility with the vscode language server which needs to "compile" include files to validate syntax errors even if they don't produce compiled code.

## Testing

Manual testing with the following types of `.nss` scripts:
- Script with a `void main()`
  - With intentional syntax errors - fails with correct error message
  - Without intentional syntax errors - succeeds
- Script with a `StartingConditional`
  - With intentional syntax errors - fails with correct error message
  - Without intentional syntax errors - succeeds
- Script without a `void main()` or `StartingConditional`
  - With intentional syntax errors - fails with correct error message
  - Without intentional syntax errors - succeeds

## Changelog

### Added
- Added `-n` / `--no-entry-point` flag to `nwn_script_comp` which allows the compilation of a file (or files) without requiring an entry point. Useful for validating files.

## Licence
- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
