### PR TITLE
Add `-E` /  `--all-errors` flag to `nwn_script_comp`

### DIFF
--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -30,11 +30,16 @@ type
   ResManWriteToFile = proc (fn: cstring, resType: uint16, pData: ptr uint8, size: csize_t, bin: bool): int32 {.cdecl.}
   ResManLoadScriptSourceFile = proc (fn: cstring, resType: uint16): bool {.cdecl.}
 
+  CompileError* = tuple
+    code: int32
+    str: string
+
   CompileResult* = tuple
     code: int32
     str: string
     bytecode: string  # "" if none written
     debugcode: string # "" if none written
+    errors: seq[CompileError]  # All errors when multi-error mode is enabled
 
 type
   # Needs to match scriptcomp.h
@@ -67,6 +72,10 @@ proc scriptCompApiInitCompiler(
 proc scriptCompApiCompileFile(instance: CScriptCompiler, fn: cstring): tuple[code: int32, str: cstring] {.importc.}
 
 proc scriptCompApiDeliverFile(instance: CScriptCompiler, data: cstring, size: csize_t) {.importc.}
+
+proc scriptCompApiSetCollectAllErrors(instance: CScriptCompiler, state: bool) {.importc.}
+proc scriptCompApiGetCollectedErrorCount(instance: CScriptCompiler): int32 {.importc.}
+proc scriptCompApiGetCollectedError(instance: CScriptCompiler, index: int32): tuple[code: int32, str: cstring] {.importc.}
 
 # Since the C level API calls back for each invocation, we need to cache the
 # currently-calling compiler instance here. This makes all procs threadsafe, as long
@@ -200,6 +209,14 @@ proc compileFile*(instance: ScriptCompiler, fn: string): CompileResult =
   result.code = q.code * -1
   result.str  = strip $(q.str)
 
+  # Populate collected errors when multi-error mode is active
+  let errorCount = scriptCompApiGetCollectedErrorCount(instance.compiler)
+  if errorCount > 0:
+    result.errors = newSeq[CompileError](errorCount)
+    for i in 0..<errorCount:
+      let e = scriptCompApiGetCollectedError(instance.compiler, i.int32)
+      result.errors[i] = (code: e.code * -1, str: strip $(e.str))
+
 proc scriptCompApiGetOptimizationFlags(instance: CScriptCompiler): uint32 {.importc.}
 proc scriptCompApiSetOptimizationFlags(instance: CScriptCompiler, flags: uint32) {.importc.}
 
@@ -226,3 +243,9 @@ proc setRequireEntryPoint*(instance: ScriptCompiler, required: bool) =
   ## When set to false, scripts without entry points can be compiled for validation purposes.
   ## This is useful for validating include files.
   scriptCompApiSetRequireEntryPoint(instance.compiler, if required: 1 else: 0)
+
+proc setCollectAllErrors*(instance: ScriptCompiler, state: bool) =
+  ## Enable or disable multi-error collection mode.
+  ## When enabled, the compiler will attempt to recover from parse errors and
+  ## continue compiling to collect additional errors.
+  scriptCompApiSetCollectAllErrors(instance.compiler, state)

--- a/neverwinter/nwscript/compiler.nim
+++ b/neverwinter/nwscript/compiler.nim
@@ -218,3 +218,11 @@ proc scriptCompApiSetGenerateDebuggerOutput(instance: CScriptCompiler, state: ui
 
 proc setGenerateDebuggerOutput*(instance: ScriptCompiler, state: bool) =
   scriptCompApiSetGenerateDebuggerOutput(instance.compiler, if state: 1 else: 0)
+
+proc scriptCompApiSetRequireEntryPoint(instance: CScriptCompiler, state: uint32) {.importc.}
+
+proc setRequireEntryPoint*(instance: ScriptCompiler, required: bool) =
+  ## Set whether an entry point (void main or int StartingConditional) is required.
+  ## When set to false, scripts without entry points can be compiled for validation purposes.
+  ## This is useful for validating include files.
+  scriptCompApiSetRequireEntryPoint(instance.compiler, if required: 1 else: 0)

--- a/neverwinter/nwscript/compilerapi.cpp
+++ b/neverwinter/nwscript/compilerapi.cpp
@@ -73,6 +73,11 @@ extern "C" void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance
     instance->SetGenerateDebuggerOutput(state);
 }
 
+extern "C" void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state)
+{
+    instance->SetRequireEntryPoint(state);
+}
+
 extern "C" void scriptCompApiDestroyCompiler(CScriptCompiler* instance)
 {
     delete instance;

--- a/neverwinter/nwscript/compilerapi.cpp
+++ b/neverwinter/nwscript/compilerapi.cpp
@@ -5,7 +5,8 @@
 extern "C" int32_t scriptCompApiGetABIVersion()
 {
     // Increment this whenever you make ABI-incompatible changes.
-    return 1;
+    // v2: Added multi-error collection API (SetCollectAllErrors, GetCollectedErrorCount, GetCollectedError)
+    return 2;
 }
 
 extern "C" CScriptCompiler* scriptCompApiNewCompiler(int src, int bin, int dbg,
@@ -76,6 +77,32 @@ extern "C" void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance
 extern "C" void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state)
 {
     instance->SetRequireEntryPoint(state);
+}
+
+extern "C" void scriptCompApiSetCollectAllErrors(CScriptCompiler* instance, bool state)
+{
+    instance->SetCollectAllErrors(state ? TRUE : FALSE);
+}
+
+extern "C" int32_t scriptCompApiGetCollectedErrorCount(CScriptCompiler* instance)
+{
+    return instance->GetCollectedErrorCount();
+}
+
+extern "C" NativeCompileResult scriptCompApiGetCollectedError(CScriptCompiler* instance, int32_t index)
+{
+    NativeCompileResult ret;
+    if (index >= 0 && index < instance->GetCollectedErrorCount())
+    {
+        ret.code = instance->GetCollectedErrorStrRef(index);
+        ret.str = instance->GetCollectedError(index).CStr();
+    }
+    else
+    {
+        ret.code = 0;
+        ret.str = "";
+    }
+    return ret;
 }
 
 extern "C" void scriptCompApiDestroyCompiler(CScriptCompiler* instance)

--- a/neverwinter/nwscript/compilerapi.h
+++ b/neverwinter/nwscript/compilerapi.h
@@ -134,6 +134,28 @@ EXPORT_SYMBOL void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* insta
 EXPORT_SYMBOL void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state);
 
 //
+// Enable or disable multi-error collection mode.
+// When enabled, the compiler will attempt to recover from parse errors and
+// continue compiling to collect additional errors. The first error is always
+// accurate; subsequent errors may include false positives.
+// Default: disabled (compiler stops at first error).
+//
+EXPORT_SYMBOL void scriptCompApiSetCollectAllErrors(CScriptCompiler* instance, bool state);
+
+//
+// Get the number of errors collected during the last compilation.
+// Only meaningful when multi-error collection is enabled.
+// Returns 0 if no errors were collected or multi-error mode is disabled.
+//
+EXPORT_SYMBOL int32_t scriptCompApiGetCollectedErrorCount(CScriptCompiler* instance);
+
+//
+// Get a specific collected error by index (0-based).
+// Only meaningful when multi-error collection is enabled and index < GetCollectedErrorCount().
+//
+EXPORT_SYMBOL NativeCompileResult scriptCompApiGetCollectedError(CScriptCompiler* instance, int32_t index);
+
+//
 // Destroy the compiler instance. You should call this when you're done
 // using it to free allocated memory.
 //

--- a/neverwinter/nwscript/compilerapi.h
+++ b/neverwinter/nwscript/compilerapi.h
@@ -127,6 +127,13 @@ EXPORT_SYMBOL void scriptCompApiSetOptimizationFlags(CScriptCompiler* instance, 
 EXPORT_SYMBOL void scriptCompApiSetGenerateDebuggerOutput(CScriptCompiler* instance, bool state);
 
 //
+// Set whether an entry point (void main or int StartingConditional) is required.
+// When set to false, scripts without entry points can be compiled for validation purposes.
+// This is useful for validating include files.
+//
+EXPORT_SYMBOL void scriptCompApiSetRequireEntryPoint(CScriptCompiler* instance, bool state);
+
+//
 // Destroy the compiler instance. You should call this when you're done
 // using it to free allocated memory.
 //

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -249,6 +249,23 @@ public:
 	///////////////////////////////////////////////////////////////////////
 
 	///////////////////////////////////////////////////////////////////////
+	void SetRequireEntryPoint(BOOL bValue);
+	//---------------------------------------------------------------------
+	// Desc.: This routine will set whether an entry point (void main or
+	//        int StartingConditional) is required for compilation.
+	//
+	// bValue:  (IN) A value to determine whether an entry point is required.
+	//
+	//          TRUE (default):  An entry point is required. Compilation
+	//              will fail if neither void main() nor
+	//              int StartingConditional() is present.
+	//
+	//          FALSE:  No entry point is required. Useful for validating
+	//              include files that have no entry point.
+	//
+	///////////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////////////////
 	int32_t CompileFile(const CExoString &sFileName);
 	//---------------------------------------------------------------------
 	// Desc.: This routine will generate whether the code in the file
@@ -485,6 +502,7 @@ private:
 	BOOL m_bCompileConditionalFile;
 	BOOL m_bOldCompileConditionalFile;
 	BOOL m_bCompileConditionalOrMain;
+	BOOL m_bRequireEntryPoint;
 	CExoString m_sLanguageSource;
 	CExoString m_sOutputAlias;
 	CExoString m_sGraphvizPath;

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -705,4 +705,20 @@ private:
 
 	CExoString  m_sCapturedError;
     STRREF      m_nCapturedErrorStrRef;
+
+	// Multi-error collection support.
+	// When m_bCollectAllErrors is TRUE, errors are accumulated into vectors
+	// instead of stopping at the first error. The parser will attempt to
+	// recover and continue parsing after each error.
+	BOOL m_bCollectAllErrors;
+	int32_t m_nMaxCollectedErrors;
+	std::vector<CExoString> m_vCapturedErrors;
+	std::vector<STRREF> m_vnCapturedErrorStrRefs;
+
+public:
+	void SetCollectAllErrors(BOOL bValue) { m_bCollectAllErrors = bValue; }
+	BOOL GetCollectAllErrors() const { return m_bCollectAllErrors; }
+	int32_t GetCollectedErrorCount() const { return (int32_t)m_vCapturedErrors.size(); }
+	const CExoString& GetCollectedError(int32_t index) const { EXOASSERT(index >= 0 && index < (int32_t)m_vCapturedErrors.size()); return m_vCapturedErrors[index]; }
+	STRREF GetCollectedErrorStrRef(int32_t index) const { EXOASSERT(index >= 0 && index < (int32_t)m_vnCapturedErrorStrRefs.size()); return m_vnCapturedErrorStrRefs[index]; }
 };

--- a/neverwinter/nwscript/native/scriptcomp.h
+++ b/neverwinter/nwscript/native/scriptcomp.h
@@ -714,6 +714,7 @@ private:
 	int32_t m_nMaxCollectedErrors;
 	std::vector<CExoString> m_vCapturedErrors;
 	std::vector<STRREF> m_vnCapturedErrorStrRefs;
+	CScriptParseTreeNode *m_pSavedParseTree;  // Completed function trees saved before error recovery
 
 public:
 	void SetCollectAllErrors(BOOL bValue) { m_bCollectAllErrors = bValue; }

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -341,6 +341,7 @@ CScriptCompiler::CScriptCompiler(RESTYPE nSource, RESTYPE nCompiled, RESTYPE nDe
 	m_bCompileConditionalFile = FALSE;
 	m_bOldCompileConditionalFile = FALSE;
 	m_bCompileConditionalOrMain = FALSE;
+	m_bRequireEntryPoint = TRUE;
 	m_bAutomaticCleanUpAfterCompiles = TRUE;
 
 	m_nNumEngineDefinedStructures = 0;
@@ -1144,6 +1145,14 @@ void CScriptCompiler::SetCompileConditionalFile(BOOL bValue)
 void CScriptCompiler::SetCompileConditionalOrMain(BOOL bValue)
 {
 	m_bCompileConditionalOrMain = bValue;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//  CScriptCompiler::SetRequireEntryPoint()
+///////////////////////////////////////////////////////////////////////////////
+void CScriptCompiler::SetRequireEntryPoint(BOOL bValue)
+{
+	m_bRequireEntryPoint = bValue;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -364,6 +364,7 @@ CScriptCompiler::CScriptCompiler(RESTYPE nSource, RESTYPE nCompiled, RESTYPE nDe
 
 	m_bCollectAllErrors = FALSE;
 	m_nMaxCollectedErrors = 100;
+	m_pSavedParseTree = NULL;
 
 	Initialize();
 
@@ -1290,6 +1291,16 @@ int32_t CScriptCompiler::CompileFile(const CExoString &sFileName)
 	// If errors were accumulated, skip code generation and return the first error code.
 	if (m_bCollectAllErrors && !m_vCapturedErrors.empty())
 	{
+		// Walk any saved complete function trees to detect semantic errors
+		// even when parsing had errors.
+		if (m_pSavedParseTree != NULL && m_nCompileFileLevel == 1)
+		{
+			InitializeFinalCode();
+			CScriptParseTreeNode *pTree = InsertGlobalVariablesInParseTree(m_pSavedParseTree);
+			WalkParseTree(pTree);
+			// Code buffer not needed — we only wanted semantic error detection.
+			// CleanUpAfterCompile or the final teardown will handle memory.
+		}
 		m_pcIncludeFileStack[m_nCompileFileLevel-1].m_sSourceScript = "";
 		--m_nCompileFileLevel;
 		return STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED;

--- a/neverwinter/nwscript/native/scriptcompcore.cpp
+++ b/neverwinter/nwscript/native/scriptcompcore.cpp
@@ -362,6 +362,9 @@ CScriptCompiler::CScriptCompiler(RESTYPE nSource, RESTYPE nCompiled, RESTYPE nDe
     m_nDeliveredFileDataSize = 0;
     m_nDeliveredFileSize = 0;
 
+	m_bCollectAllErrors = FALSE;
+	m_nMaxCollectedErrors = 100;
+
 	Initialize();
 
 }
@@ -498,6 +501,8 @@ void CScriptCompiler::Initialize( )
 
 	m_sCapturedError = "";
     m_nCapturedErrorStrRef = 0;
+	m_vCapturedErrors.clear();
+	m_vnCapturedErrorStrRefs.clear();
 
 	m_nLines = 1;
 	m_nCharacterOnLine = 1;
@@ -1281,6 +1286,15 @@ int32_t CScriptCompiler::CompileFile(const CExoString &sFileName)
 		return nReturnValue;
 	}
 
+	// In multi-error mode, ParseSource returns 0 even when errors were collected.
+	// If errors were accumulated, skip code generation and return the first error code.
+	if (m_bCollectAllErrors && !m_vCapturedErrors.empty())
+	{
+		m_pcIncludeFileStack[m_nCompileFileLevel-1].m_sSourceScript = "";
+		--m_nCompileFileLevel;
+		return STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED;
+	}
+
 	// We have successfully compiled this file.  If we are still in
 	// the middle of another CompileFile (i.e. this is an included
 	// file, return success back to the main routine.
@@ -1520,7 +1534,7 @@ int32_t CScriptCompiler::OutputError(int32_t nError, CExoString *psFileName, int
 		}
 	}
 
-	m_sCapturedError = sFullErrorText;
+	CExoString sFinalError = sFullErrorText;
 
     CExoString sTraceIncludes = "";
     for (int i = 1; i < m_nCompileFileLevel; i++)
@@ -1533,10 +1547,26 @@ int32_t CScriptCompiler::OutputError(int32_t nError, CExoString *psFileName, int
 
     if (!sTraceIncludes.IsEmpty())
     {
-        m_sCapturedError.Format("%s [via:%s]", m_sCapturedError.CStr(), sTraceIncludes.CStr());
+        sFinalError.Format("%s [via:%s]", sFinalError.CStr(), sTraceIncludes.CStr());
     }
 
-    m_nCapturedErrorStrRef = nError;
+    if (m_bCollectAllErrors)
+    {
+        m_vCapturedErrors.push_back(sFinalError);
+        m_vnCapturedErrorStrRefs.push_back(nError);
+
+        // Keep m_sCapturedError set to the first error for backward compatibility
+        if (m_vCapturedErrors.size() == 1)
+        {
+            m_sCapturedError = sFinalError;
+            m_nCapturedErrorStrRef = nError;
+        }
+    }
+    else
+    {
+        m_sCapturedError = sFinalError;
+        m_nCapturedErrorStrRef = nError;
+    }
 
 	// Print the full error text to the log file.
     // This is used and parsed by the toolset :( Do not remove.

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -84,6 +84,14 @@ int32_t CScriptCompiler::GenerateFinalCodeFromParseTree(CExoString sFileName)
 
 	int32_t nReturnValue = InstallLoader();
 	pNewReturnTree = InsertGlobalVariablesInParseTree(pReturnTree);
+
+	// InstallLoader returns 1 when no entry point is required and none was found.
+	// In this case, parsing was successful but there is no code to generate.
+	if (nReturnValue == 1)
+	{
+		return CleanUpAfterCompile(0, pNewReturnTree);
+	}
+
 	if (nReturnValue >= 0)
 	{
 		nReturnValue = WalkParseTree(pNewReturnTree);
@@ -499,7 +507,13 @@ int32_t CScriptCompiler::InstallLoader()
 			}
 			else
 			{
-				// Neither are present, so we're going to error just as
+				// Neither are present.
+				if (m_bRequireEntryPoint == FALSE)
+				{
+					// No entry point required - signal caller to skip code generation.
+					return 1;
+				}
+				// Otherwise we're going to error just as
 				// if we are expecting a void main() function!
 				m_bCompileConditionalFile = FALSE;
 			}
@@ -511,6 +525,11 @@ int32_t CScriptCompiler::InstallLoader()
 		nMainIdentifier = GetIdentifierByName("main");
 		if (nMainIdentifier < 0)
 		{
+			if (m_bRequireEntryPoint == FALSE)
+			{
+				// No entry point required - signal caller to skip code generation.
+				return 1;
+			}
 			return STRREF_CSCRIPTCOMPILER_ERROR_NO_FUNCTION_MAIN_IN_SCRIPT;
 		}
 
@@ -532,6 +551,11 @@ int32_t CScriptCompiler::InstallLoader()
 		nMainIdentifier = GetIdentifierByName("StartingConditional");
 		if (nMainIdentifier < 0)
 		{
+			if (m_bRequireEntryPoint == FALSE)
+			{
+				// No entry point required - signal caller to skip code generation.
+				return 1;
+			}
 			return STRREF_CSCRIPTCOMPILER_ERROR_NO_FUNCTION_INTSC_IN_SCRIPT;
 		}
 

--- a/neverwinter/nwscript/native/scriptcompfinalcode.cpp
+++ b/neverwinter/nwscript/native/scriptcompfinalcode.cpp
@@ -89,6 +89,16 @@ int32_t CScriptCompiler::GenerateFinalCodeFromParseTree(CExoString sFileName)
 	// In this case, parsing was successful but there is no code to generate.
 	if (nReturnValue == 1)
 	{
+		// In multi-error mode, still walk the parse tree to detect semantic errors
+		// (type mismatches, undeclared identifiers, etc.) even in include files.
+		if (m_bCollectAllErrors)
+		{
+			WalkParseTree(pNewReturnTree);
+			if (!m_vCapturedErrors.empty())
+			{
+				return CleanUpAfterCompile(STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED, pNewReturnTree);
+			}
+		}
 		return CleanUpAfterCompile(0, pNewReturnTree);
 	}
 
@@ -135,6 +145,13 @@ int32_t CScriptCompiler::GenerateFinalCodeFromParseTree(CExoString sFileName)
 			fprintf(f, "}\n");
 			fclose(f);
 		}
+	}
+
+	// In multi-error mode, if errors were accumulated during the tree walk,
+	// skip code output and clean up. The errors are already captured.
+	if (m_bCollectAllErrors && !m_vCapturedErrors.empty())
+	{
+		return CleanUpAfterCompile(STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED, pNewReturnTree);
 	}
 
 	if (nReturnValue < 0)
@@ -6345,7 +6362,40 @@ int32_t CScriptCompiler::WalkParseTree(CScriptParseTreeNode *pNode)
 		if (nReturnCode == 0)
 		{
 			pNode->pLeft = TrimParseTree(pNode->pLeft);
-			nReturnCode = WalkParseTree(pNode->pLeft);
+
+			// In multi-error mode, when walking a FUNCTIONAL_UNIT (top-level list node),
+			// save state before walking the left child (a function). If it errors,
+			// roll back state and continue to the right child (next function).
+			if (m_bCollectAllErrors &&
+			    pNode->nOperation == CSCRIPTCOMPILER_OPERATION_FUNCTIONAL_UNIT)
+			{
+				int32_t savedOutputCodeLength = m_nOutputCodeLength;
+				int32_t savedOccupiedVariables = m_nOccupiedVariables;
+				int32_t savedStackCurrentDepth = m_nStackCurrentDepth;
+				int32_t savedVarStackRecursionLevel = m_nVarStackRecursionLevel;
+
+				nReturnCode = WalkParseTree(pNode->pLeft);
+
+				if (nReturnCode < 0)
+				{
+					// Error already captured via OutputError/OutputWalkTreeError.
+					// Roll back code generation state to before this function.
+					m_nOutputCodeLength = savedOutputCodeLength;
+					m_nOccupiedVariables = savedOccupiedVariables;
+					m_nStackCurrentDepth = savedStackCurrentDepth;
+					m_nVarStackRecursionLevel = savedVarStackRecursionLevel;
+
+					// Continue to next function unless error limit reached.
+					if ((int32_t)m_vCapturedErrors.size() < m_nMaxCollectedErrors)
+					{
+						nReturnCode = 0;
+					}
+				}
+			}
+			else
+			{
+				nReturnCode = WalkParseTree(pNode->pLeft);
+			}
 		}
 
 		if (nReturnCode == 0)

--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -4668,6 +4668,57 @@ int32_t CScriptCompiler::ParseSource(const char *pScript, int32_t nScriptLength)
 					++i;
 				}
 
+				// --- Save completed function trees before recovery destroys the stack ---
+				if (m_bCollectAllErrors)
+				{
+					// The SR stack contains a ladder of FUNCTIONAL_UNIT nodes
+					// from the recursive PROGRAM grammar. Each FU with a non-NULL
+					// pLeft has a completed function body. Collect these and chain
+					// them via pRight links for later semantic analysis.
+					CScriptParseTreeNode *pChainHead = NULL;
+					CScriptParseTreeNode *pChainTail = NULL;
+
+					for (int32_t idx = 0; idx <= m_nSRStackStates; idx++)
+					{
+						CScriptParseTreeNode *p = m_pSRStack[idx].pCurrentTree;
+						if (p != NULL &&
+						    p->nOperation == CSCRIPTCOMPILER_OPERATION_FUNCTIONAL_UNIT &&
+						    p->pLeft != NULL)
+						{
+							// Detach from stack so DeleteCompileStack won't Clean() it
+							m_pSRStack[idx].pCurrentTree = NULL;
+							p->pRight = NULL;
+
+							if (pChainHead == NULL)
+							{
+								pChainHead = p;
+								pChainTail = p;
+							}
+							else
+							{
+								pChainTail->pRight = p;
+								pChainTail = p;
+							}
+						}
+					}
+
+					// Append collected chain to the saved tree accumulator
+					if (pChainHead != NULL)
+					{
+						if (m_pSavedParseTree == NULL)
+						{
+							m_pSavedParseTree = pChainHead;
+						}
+						else
+						{
+							CScriptParseTreeNode *pEnd = m_pSavedParseTree;
+							while (pEnd->pRight) pEnd = pEnd->pRight;
+							pEnd->pRight = pChainHead;
+						}
+					}
+				}
+				// --- End save ---
+
 				// Reset the parser state to top-level context
 				TokenInitialize();
 				DeleteCompileStack();
@@ -4724,6 +4775,78 @@ int32_t CScriptCompiler::ParseSource(const char *pScript, int32_t nScriptLength)
 	// as the parser state may not be in a valid terminal state after recovery.
 	if (m_bCollectAllErrors && !m_vCapturedErrors.empty())
 	{
+		// Save any post-recovery parsed functions from the stack.
+		// After error recovery, the parser may have successfully parsed
+		// additional functions. Collect them the same way as in recovery.
+		{
+			CScriptParseTreeNode *pChainHead = NULL;
+			CScriptParseTreeNode *pChainTail = NULL;
+
+			for (int32_t idx = 0; idx <= m_nSRStackStates; idx++)
+			{
+				CScriptParseTreeNode *p = m_pSRStack[idx].pCurrentTree;
+				if (p == NULL) continue;
+
+				if (p->nOperation == CSCRIPTCOMPILER_OPERATION_FUNCTIONAL_UNIT &&
+				    p->pLeft != NULL)
+				{
+					m_pSRStack[idx].pCurrentTree = NULL;
+					p->pRight = NULL;
+					if (pChainHead == NULL)
+					{
+						pChainHead = p;
+						pChainTail = p;
+					}
+					else
+					{
+						pChainTail->pRight = p;
+						pChainTail = p;
+					}
+				}
+				else if (p->nOperation == CSCRIPTCOMPILER_OPERATION_FUNCTION)
+				{
+					// The function may have a completed body in pReturnTree
+					// that hasn't been linked yet (e.g., FUNCTIONAL_UNIT rule 2
+					// term 8 was pending when we reached EOF). Complete the
+					// reduction manually.
+					CScriptParseTreeNode *pr = m_pSRStack[idx].pReturnTree;
+					if (pr != NULL && p->pRight == NULL)
+					{
+						p->pRight = pr;
+						m_pSRStack[idx].pReturnTree = NULL;
+					}
+
+					// Wrap bare FUNCTION nodes in FUNCTIONAL_UNIT
+					CScriptParseTreeNode *pFU = CreateScriptParseTreeNode(
+						CSCRIPTCOMPILER_OPERATION_FUNCTIONAL_UNIT, p, NULL);
+					m_pSRStack[idx].pCurrentTree = NULL;
+					if (pChainHead == NULL)
+					{
+						pChainHead = pFU;
+						pChainTail = pFU;
+					}
+					else
+					{
+						pChainTail->pRight = pFU;
+						pChainTail = pFU;
+					}
+				}
+			}
+
+			if (pChainHead != NULL)
+			{
+				if (m_pSavedParseTree == NULL)
+				{
+					m_pSavedParseTree = pChainHead;
+				}
+				else
+				{
+					CScriptParseTreeNode *pEnd = m_pSavedParseTree;
+					while (pEnd->pRight) pEnd = pEnd->pRight;
+					pEnd->pRight = pChainHead;
+				}
+			}
+		}
 		return 0;
 	}
 

--- a/neverwinter/nwscript/native/scriptcompparsetree.cpp
+++ b/neverwinter/nwscript/native/scriptcompparsetree.cpp
@@ -4468,6 +4468,14 @@ int32_t CScriptCompiler::PrintParseSourceError(int32_t nParsingError)
 
 	OutputError(nParsingError,psFileName,m_nLines,sErrorText);
 
+	// In multi-error mode, don't tear down the compiler state.
+	// Return a positive sentinel value so ParseSource() can recover and continue.
+	if (m_bCollectAllErrors)
+	{
+		m_sParserErrorExtraInfo = "";
+		return 1; // Positive: signals ParseSource to recover
+	}
+
 	nParsingError = STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED;
 
 	return CleanUpDuringCompile(nParsingError);
@@ -4590,7 +4598,87 @@ int32_t CScriptCompiler::ParseSource(const char *pScript, int32_t nScriptLength)
 
 		if (nParseNextCharReturn < 0)
 		{
-			return PrintParseSourceError(nParseNextCharReturn);
+			int32_t nErrorResult = PrintParseSourceError(nParseNextCharReturn);
+
+			// In multi-error mode, PrintParseSourceError returns positive (1) to signal recovery.
+			// We skip forward to a synchronization point and reset the parser state.
+			if (m_bCollectAllErrors && nErrorResult > 0)
+			{
+				// Check if we've hit the error limit
+				if ((int32_t)m_vCapturedErrors.size() >= m_nMaxCollectedErrors)
+				{
+					return STRREF_CSCRIPTCOMPILER_ERROR_ALREADY_PRINTED;
+				}
+
+				// Skip forward to a synchronization point.
+				// We look for ';' or '}' at brace depth 0 relative to current position.
+				int32_t nBraceDepth = 0;
+				bool bFoundSync = false;
+
+				while (ch != -1 && !bFoundSync)
+				{
+					if (ch == '{')
+					{
+						++nBraceDepth;
+					}
+					else if (ch == '}')
+					{
+						if (nBraceDepth > 0)
+						{
+							--nBraceDepth;
+							if (nBraceDepth == 0)
+							{
+								// Closed back to top-level (e.g. end of function body) - sync here
+								bFoundSync = true;
+							}
+						}
+						else
+						{
+							// Found an unmatched closing brace at depth 0 - sync after it
+							bFoundSync = true;
+						}
+					}
+					else if (ch == ';' && nBraceDepth == 0)
+					{
+						// Found a semicolon at depth 0 - sync after it
+						bFoundSync = true;
+					}
+
+					// Track line numbers during skip
+					if (ch == '\n')
+					{
+						++m_nLines;
+						m_nCharacterOnLine = 1;
+					}
+					else
+					{
+						++m_nCharacterOnLine;
+					}
+
+					// Advance to next character
+					ch = chNext;
+					if (i >= nScriptLength)
+					{
+						chNext = -1;
+					}
+					else
+					{
+						chNext = (unsigned char) pScript[i];
+					}
+					++i;
+				}
+
+				// Reset the parser state to top-level context
+				TokenInitialize();
+				DeleteCompileStack();
+				m_nSRStackStates = -1;
+				PushSRStack(0, 0, 0, NULL);
+
+				continue;
+			}
+
+			// Normal mode: return the error immediately
+			return nErrorResult;
 		}
 
 		while (nParseNextCharReturn >= 0)
@@ -4631,6 +4719,13 @@ int32_t CScriptCompiler::ParseSource(const char *pScript, int32_t nScriptLength)
 	// Parse an EOF.
 	//
 	///////////////////////////////////////////////
+
+	// In multi-error mode, if we've already collected errors, don't try to parse EOF
+	// as the parser state may not be in a valid terminal state after recovery.
+	if (m_bCollectAllErrors && !m_vCapturedErrors.empty())
+	{
+		return 0;
+	}
 
 	nParseNextCharReturn = ParseNextCharacter(-1,-1, nullptr, 0);
 

--- a/nwn_script_comp.nim
+++ b/nwn_script_comp.nim
@@ -53,6 +53,10 @@ Usage:
                               int StartingConditional). Useful for validating
                               include files.
 
+  -E --all-errors             Collect and report all errors per file instead
+                              of stopping at the first error. Useful for IDEs
+                              and language servers.
+
   --langspec NSS              Language spec to load [default: nwscript]
   --restype-src TYPE          ResType to use for source lookup [default: nss]
   --restype-bin TYPE          ResType to use for binary output [default: ncs]
@@ -76,6 +80,7 @@ type
     followSymlinks: bool
     graphvizOut: string
     requireEntryPoint: bool
+    collectAllErrors: bool
 
   GlobalState = object
     successes, errors, skips: Atomic[uint]
@@ -122,6 +127,7 @@ globalState.params = Params(
   followSymlinks: globalState.args["--follow-symlinks"],
   graphvizOut: if globalState.args["--graphviz"]: ($globalState.args["--graphviz"]) else: "",
   requireEntryPoint: not globalState.args["--no-entry-point"].to_bool,
+  collectAllErrors: globalState.args["--all-errors"].to_bool,
 )
 
 if globalState.params.outDirectory != "" and not dirExists(globalState.params.outDirectory):
@@ -214,6 +220,7 @@ proc getThreadState(): ThreadState {.gcsafe.} =
     state.cNSS = newCompiler(params.langSpec, params.debugSymbols, resolveFile, params.maxIncludeDepth, params.graphvizOut)
     state.cNSS.setOptimizations(params.optFlags)
     state.cNSS.setRequireEntryPoint(params.requireEntryPoint)
+    state.cNSS.setCollectAllErrors(params.collectAllErrors)
   state
 
 proc doCompile(num, total: Positive, p: string, overrideOutPath: string = "") {.gcsafe.} =
@@ -268,7 +275,24 @@ proc doCompile(num, total: Positive, p: string, overrideOutPath: string = "") {.
         debug prefix, "no main (include?)", timingPostfix()
       else:
         atomicInc globalState.errors
-        if params.continueOnError:
+
+        if params.collectAllErrors and ret.errors.len > 0:
+          # Multi-error mode: print each collected error as a separate log line
+          for idx, e in ret.errors:
+            if idx == 0:
+              if params.continueOnError:
+                error prefix, e.str, timingPostfix()
+              else:
+                fatal prefix, e.str, timingPostfix()
+            else:
+              if params.continueOnError:
+                error prefix, e.str
+              else:
+                fatal prefix, e.str
+
+          if not params.continueOnError:
+            quit(1)
+        elif params.continueOnError:
           error prefix, ret.str, timingPostfix()
         else:
           fatal prefix, ret.str, timingPostfix()

--- a/nwn_script_comp.nim
+++ b/nwn_script_comp.nim
@@ -49,6 +49,10 @@ Usage:
   -s                          Simulate: Compile, but write no file.
                               Use --verbose to see what would be written.
 
+  -n --no-entry-point         Do not require an entry point (void main or
+                              int StartingConditional). Useful for validating
+                              include files.
+
   --langspec NSS              Language spec to load [default: nwscript]
   --restype-src TYPE          ResType to use for source lookup [default: nss]
   --restype-bin TYPE          ResType to use for binary output [default: ncs]
@@ -71,6 +75,7 @@ type
     maxIncludeDepth: 1..200
     followSymlinks: bool
     graphvizOut: string
+    requireEntryPoint: bool
 
   GlobalState = object
     successes, errors, skips: Atomic[uint]
@@ -116,6 +121,7 @@ globalState.params = Params(
   maxIncludeDepth: parseInt($globalState.args["--max-include-depth"]),
   followSymlinks: globalState.args["--follow-symlinks"],
   graphvizOut: if globalState.args["--graphviz"]: ($globalState.args["--graphviz"]) else: "",
+  requireEntryPoint: not globalState.args["--no-entry-point"].to_bool,
 )
 
 if globalState.params.outDirectory != "" and not dirExists(globalState.params.outDirectory):
@@ -207,6 +213,7 @@ proc getThreadState(): ThreadState {.gcsafe.} =
     state.chDemandResRefResponse.open(maxItems=1)
     state.cNSS = newCompiler(params.langSpec, params.debugSymbols, resolveFile, params.maxIncludeDepth, params.graphvizOut)
     state.cNSS.setOptimizations(params.optFlags)
+    state.cNSS.setRequireEntryPoint(params.requireEntryPoint)
   state
 
 proc doCompile(num, total: Positive, p: string, overrideOutPath: string = "") {.gcsafe.} =


### PR DESCRIPTION
Built on top of https://github.com/niv/neverwinter.nim/pull/152 and dependent on it. If I could have made that branch the base and have it still show in this repo, I would have.

Adds a new `-E` / `--all-errors` flag to `nwn_script_comp` that collects and reports all compilation errors in a file instead of stopping at the first one. This is useful for (potential) IDEs, language servers, and batch validation workflows.

### Multi-error collection infrastructure

The compiler gains a multi-error mode controlled by `SetCollectAllErrors()`. When enabled:

- Parse error recovery: Instead of tearing down compiler state on a parse error, the parser captures the error, skips forward to a synchronization point (`;` or `}` at brace depth 0), resets the SR stack, and continues parsing. This allows multiple parse errors in different functions to be reported in a single pass.
- Semantic error recovery: The tree walker (`WalkParseTree`) saves and restores code-gen state around each `FUNCTIONAL_UNIT` node. A semantic error in one function rolls back that function and continues to the next.
- Error accumulation: Errors are stored in `m_vCapturedErrors` / `m_vnCapturedErrorStrRefs` vectors (up to a configurable limit) and exposed through `GetCollectedErrorCount()` / `GetCollectedError()`.
- API surface: New C API functions (`scriptCompApiSetCollectAllErrors`, `scriptCompApiGetCollectedErrorCount`, `scriptCompApiGetCollectedError`) and corresponding Nim bindings.

### Mixed parse + semantic error reporting

When a file has both parse errors and semantic errors in different functions, the initial implementation only reported parse errors; semantic errors in correctly-parsed functions were silently lost. This happened because:

1. Parse error recovery called `DeleteCompileStack()` which destroyed the entire parse tree, including already-completed functions.
2. `CompileFile` skipped `GenerateFinalCodeFromParseTree` entirely when parse errors existed, so the tree walker never ran.

The fix saves completed function subtrees from the SR stack before error recovery destroys them, accumulating them in `m_pSavedParseTree`. After parsing completes, these saved trees are walked for semantic errors via `InitializeFinalCode` + `InsertGlobalVariablesInParseTree` + `WalkParseTree`. Post-recovery functions that were parsed after the error but before EOF are also collected, including completing any pending grammar reductions (e.g., linking a function body that was still in `pReturnTree`).

For example, a file with a semantic error on line 31 and a parse error on line 43 now reports both:
```
_inc_socialrank.nss(43): ERROR: UNKNOWN STATE IN COMPILER [FUNCTIONAL_UNIT(0,6):VOID_IDENTIFIER]
_inc_socialrank.nss(31): ERROR: DECLARATION DOES NOT MATCH PARAMETERS
```

### Output format

When `-E` is active, each collected error is printed as a separate log line. Without `-E`, the compiler behaves exactly as before (stops at the first error).

## Testing

Tested with five scenarios:

| Test | Description | Result |
|------|------------|--------|
| Pure semantic errors | File with 2 type errors in separate functions | 2 semantic errors reported |
| Pure parse errors | File with 2 syntax errors in separate functions | 2 parse errors reported |
| Mixed errors | File with 1 parse error + 2 semantic errors in different functions | All 3 errors reported |
| Mixed errors again | Wrong arg count (line 31) + junk between `)` and `{` (line 43) | Both errors reported |
| No errors | Normal file | Compiles successfully (exit 0) |

Also verified normal mode (without `-E`) is unaffected.

## Changelog

### Added
- `-E` / `--all-errors` flag for `nwn_script_comp`: collects and reports all compilation errors per file instead of stopping at the first. Useful for IDEs and language servers.

## Licence

- [x] I am licencing my change under the project's MIT licence, including all changes to GPL-3.0 licenced parts of the codebase.
